### PR TITLE
Windows fixes etc. (closes #4)

### DIFF
--- a/VideoF2B_v0_5.py
+++ b/VideoF2B_v0_5.py
@@ -61,13 +61,13 @@ if not Camera.Calibrated:
 scale, inp_width, inp_height = Video.Size(Camera, cap, ImWidth)
 
 #What depends on running environment
-if platform.system() is 'Windows':
-    cv2.namedWindow(Window_name, cv2.WINDOW_AUTOSIZE )
-    fourcc = cv2.VideoWriter_fourcc(*'avc1')
+if platform.system() == 'Windows':
+    fourcc = cv2.VideoWriter_fourcc(*'mpv4')
 else:
-    cv2.namedWindow(Window_name, cv2.WINDOW_NORMAL )
     fourcc = cv2.VideoWriter_fourcc(*'H264')
-    
+
+cv2.namedWindow(Window_name, cv2.WINDOW_NORMAL )
+
 # Output file
 if not live:
     out = cv2.VideoWriter(os.path.splitext(videoPath)[0]+'_out.MP4',fourcc, cap.get(5),\

--- a/VideoF2B_v0_5.py
+++ b/VideoF2B_v0_5.py
@@ -62,7 +62,7 @@ scale, inp_width, inp_height = Video.Size(Camera, cap, ImWidth)
 
 #What depends on running environment
 if platform.system() == 'Windows':
-    fourcc = cv2.VideoWriter_fourcc(*'mpv4')
+    fourcc = cv2.VideoWriter_fourcc(*'mp4v')
 else:
     fourcc = cv2.VideoWriter_fourcc(*'H264')
 


### PR DESCRIPTION
* `WINDOW_AUTOSIZE` is problematic. It does not allow user to resize the window.  `WINDOW_KEEPRATIO` does not work as advertised, either. `WINDOW_NORMAL` seems to work best.

* `mpv4` setting in `VideoWriter_fourcc` works without errors on Windows.

* Do not perform identity comparisons on strings, or you will have a bad day someday.  Equality comparisons are more appropriate for value types.