### PR TITLE
Use the `dev` branch of `basil96/imutils` fork

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Current fork of imutils
-git+https://github.com/basil96/imutils.git
+git+https://github.com/basil96/imutils.git@dev
 # imutils>=0.5.3
 numpy>=1.21.1
 platformdirs>=2.2.0

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ VideoF2B is an open-source desktop application for tracing F2B Stunt competition
     install_requires=[
         # To list a private GitHub repo as a dependency, see the following:
         # https://stackoverflow.com/questions/18026980/python-setuptools-how-can-i-list-a-private-repository-under-install-requires
-        'imutils @ git+https://github.com/basil96/imutils.git',
+        'imutils @ git+https://github.com/basil96/imutils.git@dev',
         'numpy>=1.21.1',
         'platformdirs>=2.2.0',
         'opencv-python >= 4.5.3; platform_system=="Windows"',


### PR DESCRIPTION
* This makes more sense for now because I can keep the master branch isolated from the forked work that needs to be done to support VideoF2B.

Closes #47.