### PR TITLE
Persist state of `MainWindow`

### DIFF
--- a/videof2b/app.py
+++ b/videof2b/app.py
@@ -42,6 +42,7 @@ class VideoF2B(QtCore.QObject):
     def run(self, app):
         app.aboutToQuit.connect(self._quitting)
         self.main_window = MainWindow()
+        self.main_window.load_settings()
         self.main_window.show()
         return app.exec()
 

--- a/videof2b/core/common/settings.py
+++ b/videof2b/core/common/settings.py
@@ -17,16 +17,38 @@
 
 '''Module for handling persistent settings.'''
 
-from PySide6.QtCore import QSettings
+from pathlib import Path
+
+from PySide6.QtCore import QByteArray, QPoint, QSettings
 
 
 class Settings(QSettings):
+    '''Simple wrapper around QSettings.
+    Contains core definitions of all known keys and their default values.
+    Does not contain a strategy for versioning of settings.
+    Handles lookup of default values in the most basic manner.
+    '''
 
-    __default_settings__ = {
-        'version': 0,
-        'mru/video_dir': '..',
-        'mru/cal_dir': '..',
+    __defaults__ = {
+        'mru/video_dir': Path('..'),
+        'mru/cal_dir': Path('..'),
+        'ui/main_window_position': QPoint(0, 0),
+        'ui/main_window_geometry': QByteArray(),
+        'ui/main_window_state': QByteArray(),
     }
 
     def __init__(self, *args, **kwargs):
+        '''Initialize settings.'''
         super().__init__(*args, **kwargs)
+
+    def value(self, key):
+        '''Return the value for the given key.
+        The key must exist in `Settings.__defaults__`.
+        If value not found, return the value from `Settings.__defaults__`
+        '''
+        default_value = Settings.__defaults__[key]
+        try:
+            setting = super().value(key, default_value)
+        except TypeError:
+            setting = default_value
+        return setting

--- a/videof2b/ui/load_flight_dialog.py
+++ b/videof2b/ui/load_flight_dialog.py
@@ -59,8 +59,8 @@ class LoadFlightDialog(QtWidgets.QDialog, StoreProperties):
         self.video_path_txt = PathEdit(
             self, PathEditType.Files,
             'Select video file',
-            str_to_path(self.settings.value('mru/video_dir'))
-        )  # TODO: there must be a cleaner way to convert path<->str in settings!
+            self.settings.value('mru/video_dir')
+        )
         self.video_path_txt.filters = f'Video files ({" ".join(EXTENSIONS_VIDEO)});;All files (*)'
         #
         # TODO: insert a checkbox here that connects to `flight.is_ar_enabled` and conditionally enables/disables the entire "calibrated" group of inputs below.
@@ -69,8 +69,8 @@ class LoadFlightDialog(QtWidgets.QDialog, StoreProperties):
         self.cal_path_txt = PathEdit(
             self, PathEditType.Files,
             'Select calibration file',
-            str_to_path(self.settings.value('mru/cal_dir'))
-        )  # TODO: there must be a cleaner way to convert path<->str in settings!
+            self.settings.value('mru/cal_dir')
+        )
         self.cal_path_txt.filters = 'Calibration files (*.npz);;All files (*)'
         # Measurement inputs
         self.flight_radius_lbl = QtWidgets.QLabel(
@@ -122,12 +122,11 @@ class LoadFlightDialog(QtWidgets.QDialog, StoreProperties):
             marker_height=float(self.marker_height_txt.text())
             # TODO: include `sphere_offset` as well. Add a grid widget to UI for the XYZ values.
         )
-        # TODO: there must be a cleaner way to convert path<->str in settings!
-        self.settings.setValue('mru/video_dir', path_to_str(self.video_path_txt.path.parent))
+        self.settings.setValue('mru/video_dir', self.video_path_txt.path.parent)
         # Cal path is optional, so check it first
         cal_path = self.cal_path_txt.path
         if path_to_str(cal_path) and cal_path.exists():
-            self.settings.setValue('mru/cal_dir', path_to_str(cal_path.parent))
+            self.settings.setValue('mru/cal_dir', cal_path.parent)
         # Do not proceed if flight failed to load
         if not self.flight.is_ready:
             QtWidgets.QMessageBox.critical(

--- a/videof2b/ui/main_window.py
+++ b/videof2b/ui/main_window.py
@@ -339,8 +339,6 @@ class MainWindow(QtWidgets.QMainWindow, Ui_MainWindow, StoreProperties):
         self.act_next_figure.triggered.connect(self.on_next_figure)
         self.act_pause_resume.setEnabled(False)
         self._enable_figure_controls(False)
-        # TODO: center on main screen on first use, or use saved Settings if available.
-        self.move(5, 5)
 
     def closeEvent(self, event):
         '''Overridden to handle the closing of the main window in a safe manner.
@@ -380,6 +378,20 @@ class MainWindow(QtWidgets.QMainWindow, Ui_MainWindow, StoreProperties):
         else:
             log.debug('VideoProcessor thread is not running. MainWindow is closing...')
             event.accept()
+        if event.isAccepted():
+            self.save_settings()
+
+    def load_settings(self):
+        '''Load the settings of MainWindow.'''
+        self.move(self.settings.value('ui/main_window_position'))
+        self.restoreGeometry(self.settings.value('ui/main_window_geometry'))
+        self.restoreState(self.settings.value('ui/main_window_state'))
+
+    def save_settings(self):
+        '''Save the settings of MainWindow.'''
+        self.settings.setValue('ui/main_window_position', self.pos())
+        self.settings.setValue('ui/main_window_geometry', self.saveGeometry())
+        self.settings.setValue('ui/main_window_state', self.saveState())
 
     def on_locating_started(self):
         '''Prepare UI for the camera locating procedure.'''


### PR DESCRIPTION
* Save main window position, geometry, and state values on `closeEvent`. Load them after construction before main window is shown.

* Override `value()` in Settings to handle default values of settings.

* Also clean up how we persist paths in settings: no need to convert between `str` and `Path` just for storage. Let QSettings handle the representation.

Verified on Win10 and Ubuntu 21.04 using multi-monitor setup (2 and 3 displays).  The main window always appears on an available display on startup, even when its last recorded position was on a display that was disconnected between sessions. The Qt framework seems to handle this one well.