### PR TITLE
Add reprojection error calculation, improve fault handling

### DIFF
--- a/videof2b/ui/main_window.py
+++ b/videof2b/ui/main_window.py
@@ -316,6 +316,8 @@ class MainWindow(QtWidgets.QMainWindow, Ui_MainWindow, StoreProperties):
         CalibratorReturnCodes.Undefined: 'Calibration never started.',
         CalibratorReturnCodes.Normal: 'Calibration finished normally.',
         CalibratorReturnCodes.UserCanceled: 'Calibration was canceled by user.',
+        CalibratorReturnCodes.NoValidFrames: 'No valid frames found. Ensure the calibration pattern is clearly visible in the video.',
+        CalibratorReturnCodes.InsufficientValidFrames: 'Too few valid frames found. Ensure the calibration pattern is clearly visible and the video is long enough.',
     }
 
     # Maps object names of figure checkboxes to the common.FigureType required by core.Drawing.


### PR DESCRIPTION
* Calculate and report reprojection error after camera calibration.

* Add another return code to distinguish "insufficient valid frames" from "no valid frames".

* Factor out the validation of `ret_code` into a helper method.

* Log just the file names of calibration paths.

* Update the link to the pre-made checkerboard pattern.

Closes #56.