### PR TITLE
Allow user to skip locating a calibrated Flight

### DIFF
--- a/videof2b/core/flight.py
+++ b/videof2b/core/flight.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # VideoF2B - Draw F2B figures from video
-# Copyright (C) 2021  Andrey Vasilik - basil96
+# Copyright (C) 2021 - 2022  Andrey Vasilik - basil96
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -51,6 +51,8 @@ class Flight(QObject):
 
             `kwargs` are additional parameters when cal_path is specified.
             These are as follows:
+            `skip_locate`: indicates whether to skip the camera locating procedure
+                           in a calibrated Flight. Defaults to False.
             `flight_radius`: radius of the flight hemisphere.
             `marker_radius`: radius of the circle where the markers are located.
             `marker_height`: elevation of the marker circle above the center marker.
@@ -70,6 +72,7 @@ class Flight(QObject):
         self.is_calibrated = cal_path is not None and cal_path.exists()
         self.is_located = False
         self.is_ar_enabled = True
+        self.skip_locate = kwargs.pop('skip_locate', False)
         self.flight_radius = kwargs.pop('flight_radius', common.DEFAULT_FLIGHT_RADIUS)
         self.marker_radius = kwargs.pop('marker_radius', common.DEFAULT_MARKER_RADIUS)
         self.marker_height = kwargs.pop('marker_height', common.DEFAULT_MARKER_HEIGHT)

--- a/videof2b/core/processor.py
+++ b/videof2b/core/processor.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # VideoF2B - Draw F2B figures from video
-# Copyright (C) 2021  Andrey Vasilik - basil96
+# Copyright (C) 2021 - 2022  Andrey Vasilik - basil96
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -705,7 +705,7 @@ class VideoProcessor(QObject, StoreProperties):
                 self._frame = self.cam.undistort(self._frame)
                 # log.debug(f'frame.shape after undistort: {self._frame.shape}')
                 # log.debug(f'frame.data = {self._frame.data}')
-                if not self.flight.is_located and self.flight.is_ar_enabled:
+                if not self.flight.is_located and not self.flight.skip_locate and self.flight.is_ar_enabled:
                     log.debug('Locating the flight...')
                     self._frame_loc = self._frame
                     ret = self._locate()

--- a/videof2b/ui/load_flight_dialog.py
+++ b/videof2b/ui/load_flight_dialog.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # VideoF2B - Draw F2B figures from video
-# Copyright (C) 2021  Andrey Vasilik - basil96
+# Copyright (C) 2021 - 2022  Andrey Vasilik - basil96
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -49,6 +49,7 @@ class LoadFlightDialog(QtWidgets.QDialog, StoreProperties):
         self.setup_ui()
         self.setWindowTitle('Load a Flight')
         # pylint: disable=no-member
+        self.skip_locate_chk.stateChanged.connect(self.on_skip_locate_changed)
         self.cancel_btn.clicked.connect(self.reject)
         self.load_btn.clicked.connect(self.accept)
 
@@ -79,6 +80,7 @@ class LoadFlightDialog(QtWidgets.QDialog, StoreProperties):
             self.settings.value('mru/cal_dir')
         )
         self.cal_path_txt.filters = 'Calibration files (*.npz);;All files (*)'
+        self.skip_locate_chk = QtWidgets.QCheckBox('&Skip camera location', self)
         # Measurement inputs
         self.flight_radius_lbl = QtWidgets.QLabel(
             'Flight radius (m)', self)
@@ -109,6 +111,7 @@ class LoadFlightDialog(QtWidgets.QDialog, StoreProperties):
         self.main_layout.addWidget(self.video_path_txt)
         self.main_layout.addWidget(self.cal_path_lbl)
         self.main_layout.addWidget(self.cal_path_txt)
+        self.main_layout.addWidget(self.skip_locate_chk)
         self.main_layout.addLayout(self.meas_grid)
         self.main_layout.addSpacerItem(QtWidgets.QSpacerItem(20, 20))
         self.main_layout.addLayout(self.bottom_layout)
@@ -123,6 +126,7 @@ class LoadFlightDialog(QtWidgets.QDialog, StoreProperties):
             self.video_path_txt.path,
             cal_path=self.cal_path_txt.path,
             is_live=self.live_chk.isChecked(),
+            skip_locate=self.skip_locate_chk.isChecked(),
             # TODO: use proper validation for these numeric fields!
             flight_radius=float(self.flight_radius_txt.text()),
             marker_radius=float(self.marker_radius_txt.text()),
@@ -143,6 +147,16 @@ class LoadFlightDialog(QtWidgets.QDialog, StoreProperties):
             )
             return None  # Keeps the window up
         return super().accept()
+
+    def on_skip_locate_changed(self):
+        '''Enable/disable the measurement widgets when the "skip locate" checkbox changes.'''
+        enable = not self.sender().isChecked()
+        self.flight_radius_lbl.setEnabled(enable)
+        self.flight_radius_txt.setEnabled(enable)
+        self.marker_radius_lbl.setEnabled(enable)
+        self.marker_radius_txt.setEnabled(enable)
+        self.marker_height_lbl.setEnabled(enable)
+        self.marker_height_txt.setEnabled(enable)
 
     def _validate(self) -> bool:
         '''Validate user inputs.'''


### PR DESCRIPTION
* Introduce a checkbox in `LoadFlightDialog`.  Pass its value to the `Flight` constructor.

* Use this value to determine whether to skip the camera locating procedure during processing.

Closes #73.