### PR TITLE
Fix: update `EdgePolyline._img_pts` when `Camera` is inside AR sphere

### DIFF
--- a/videof2b/core/processor.py
+++ b/videof2b/core/processor.py
@@ -640,6 +640,11 @@ class VideoProcessor(QObject, StoreProperties):
 
     def run(self):
         '''Run the processor.'''
+        # ===== FOR DEBUGGING ONLY. DO NOT ENABLE IN PRODUCTION. =============================
+        # Allows debugging of QThreads. See https://stackoverflow.com/a/56095987/472566
+        # import pydevd; pydevd.settrace(suspend=False)  # `pip install pydevd` as needed.
+        # ====================================================================================
+
         log.debug('Entering `VideoProcessor.run()...`')
         # This exception handler is necessary because an exception
         # does not propagate from a thread to its calling thread.


### PR DESCRIPTION
* When `Camera` is located such that it ends up within the AR sphere, we were returning early and `_img_pts` in `EdgePolyline` were not updated.  This caused the unhandled exception described in #75.  This logic worked before the cache was implemented in `Drawing`, but was overlooked afterwards.

* The same condition occurs (but without a crash) if the user moves  the sphere such that the `Camera` ends up within its volume.  If the visible edge of the sphere was within the FOV at the last location of the sphere before it enclosed the `Camera`, then the edge outline will remain at that location while the rest of the sphere's features will move as expected.

* Fix by updating `_img_pts` to an empty array instead of returning early when the above condition is met.  The array is cached so that the preliminary math is only performed on demand, like in other cases.

* Add some commented-out code to the `run` method of the `VideoProcessor` thread for future debugging.  It is impossible to debug `QThread` objects without this.

Closes #75.