### PR TITLE
Draw maneuver endpoints

### DIFF
--- a/tests/core/test_drawing.py
+++ b/tests/core/test_drawing.py
@@ -76,37 +76,37 @@ def test_figure_connections(caloc_artist):
     '''Test for gaps between components of figures.'''
     # Verify connections in all figures
     # Plain loop
-    loop_pts = caloc_artist._get_loop_pts()
+    loop_pts, _ = caloc_artist._get_loop_pts()
     _verify_figure_gaps(loop_pts, is_closed=True)
     # Square loop
-    sq_loop_pts = caloc_artist._get_square_loop_pts()
+    sq_loop_pts, _ = caloc_artist._get_square_loop_pts()
     _verify_figure_gaps(sq_loop_pts, is_closed=True)
     # Triangular loop
-    tri_loop_pts = caloc_artist._get_tri_loop_pts()
+    tri_loop_pts, _ = caloc_artist._get_tri_loop_pts()
     _verify_figure_gaps(tri_loop_pts, is_closed=True)
     # Horizontal eight
-    hor_eight_pts = caloc_artist._get_hor_eight_pts()
+    hor_eight_pts, _ = caloc_artist._get_hor_eight_pts()
     _verify_figure_gaps(hor_eight_pts, is_closed=True)
     # Square eight
-    sq_eight_pts = caloc_artist._get_sq_eight_pts()
+    sq_eight_pts, _ = caloc_artist._get_sq_eight_pts()
     _verify_figure_gaps(sq_eight_pts, is_closed=True)
     # Vertical eight
-    ver_eight_pts = caloc_artist._get_ver_eight_pts()
+    ver_eight_pts, _ = caloc_artist._get_ver_eight_pts()
     _verify_figure_gaps(ver_eight_pts, is_closed=True)
     # Hourglass
-    hourglass_pts = caloc_artist._get_hourglass_pts()
+    hourglass_pts, _ = caloc_artist._get_hourglass_pts()
     _verify_figure_gaps(hourglass_pts, is_closed=True)
-    ovr_eight_pts = caloc_artist._get_ovr_eight_pts()
+    ovr_eight_pts, _ = caloc_artist._get_ovr_eight_pts()
     _verify_figure_gaps(ovr_eight_pts, is_closed=True)
     # Four-leaf clover
-    clover_pts = caloc_artist._get_clover_pts()
+    clover_pts, _ = caloc_artist._get_clover_pts()
     _verify_figure_gaps(clover_pts)
 
 
 def test_clover_tangencies(caloc_artist):
     '''Verify the elevation and azimuth angles of the four main
     tangency points of the four-leaf clover.'''
-    clover_pts = caloc_artist._get_clover_pts()
+    clover_pts, _ = caloc_artist._get_clover_pts()
     # Point 1: at bottom of vertical, tangent to vertical and to bottom loops.
     pt1 = clover_pts[0][0]
     _, pt1_theta, pt1_phi = geom.cartesian_to_spherical(pt1)

--- a/videof2b/core/processor.py
+++ b/videof2b/core/processor.py
@@ -491,6 +491,12 @@ class VideoProcessor(QObject, StoreProperties):
             self._artist.figure_state[figure_type] = val
             self._update_during_pause_flag = True
 
+    def update_maneuver_endpts(self, val: bool) -> None:
+        '''Update maneuver endpoints in the drawing.'''
+        if self.flight.is_located:  # protect artist
+            self._artist.draw_endpts = val
+            self._update_during_pause_flag = True
+
     def update_figure_diags(self, val: bool) -> None:
         '''Update figure diags state in the drawing.'''
         if self.flight.is_located:  # protect artist

--- a/videof2b/ui/main_window.py
+++ b/videof2b/ui/main_window.py
@@ -104,6 +104,9 @@ class UIMainWindow:
         # Horizontal separator 1
         self.pnl_chk.addWidget(QHLine())
         self.pnl_chk.addSpacerItem(get_vspacer())
+        # Start/end points checkbox
+        self.chk_start_end_pts = QtWidgets.QCheckBox('Draw Start/End points', main_window)
+        self.pnl_chk.addWidget(self.chk_start_end_pts)
         # Diags checkbox
         self.chk_diag = QtWidgets.QCheckBox('Draw Diagnostics', main_window)
         self.pnl_chk.addWidget(self.chk_diag)
@@ -294,6 +297,7 @@ class MainWindow(QtWidgets.QMainWindow, UIMainWindow, StoreProperties):
     clear_track = QtCore.Signal()
     figure_state_changed = QtCore.Signal(FigureTypes, bool)
     figure_diags_changed = QtCore.Signal(bool)
+    maneuver_endpts_changed = QtCore.Signal(bool)
     relocate_cam = QtCore.Signal()
     manipulate_sphere = QtCore.Signal(SphereManipulations)
     figure_mark = QtCore.Signal(bool)
@@ -492,6 +496,10 @@ class MainWindow(QtWidgets.QMainWindow, UIMainWindow, StoreProperties):
         else:
             self.act_next_figure.setEnabled(True)
 
+    def on_chk_endpts_changed(self):
+        '''Tell the processor to toggle the drawn state of maneuver start/end points.'''
+        self.maneuver_endpts_changed.emit(self.sender().isChecked())
+
     def on_chk_diag_changed(self):
         '''Tell the processor to toggle the drawn state of figure diagnostics.'''
         self.figure_diags_changed.emit(self.sender().isChecked())
@@ -518,6 +526,7 @@ class MainWindow(QtWidgets.QMainWindow, UIMainWindow, StoreProperties):
         self.video_window.point_added.connect(self._proc.add_locator_point, QtCore.Qt.QueuedConnection)
         self.video_window.point_removed.connect(self._proc.pop_locator_point, QtCore.Qt.QueuedConnection)
         self.figure_state_changed.connect(self._proc.update_figure_state, QtCore.Qt.QueuedConnection)
+        self.maneuver_endpts_changed.connect(self._proc.update_maneuver_endpts, QtCore.Qt.QueuedConnection)
         self.figure_diags_changed.connect(self._proc.update_figure_diags, QtCore.Qt.QueuedConnection)
         self.pause_resume.connect(self._proc.pause_resume, QtCore.Qt.QueuedConnection)
         self._proc.paused.connect(self.on_paused_resumed, QtCore.Qt.QueuedConnection)
@@ -534,6 +543,7 @@ class MainWindow(QtWidgets.QMainWindow, UIMainWindow, StoreProperties):
         self.act_clear_track.triggered.connect(self.on_clear_track)
         for fig_chk in self.fig_chk_boxes:
             fig_chk.stateChanged.connect(self.on_chk_figure_changed)
+        self.chk_start_end_pts.stateChanged.connect(self.on_chk_endpts_changed)
         self.chk_diag.stateChanged.connect(self.on_chk_diag_changed)
         self.act_rotate_left.triggered.connect(self.on_rotate_ccw)
         self.act_rotate_right.triggered.connect(self.on_rotate_cw)
@@ -728,6 +738,7 @@ class MainWindow(QtWidgets.QMainWindow, UIMainWindow, StoreProperties):
         '''Enables/disables all the widgets that control drawn figure state.'''
         for fig_chk in self.fig_chk_boxes:
             fig_chk.setEnabled(enable)
+        self.chk_start_end_pts.setEnabled(enable)
         self.chk_diag.setEnabled(enable)
         self.act_next_figure.setEnabled(enable)
 


### PR DESCRIPTION
Display start/end points of maneuvers

- Add UI option to draw start/end points.
- Use green & red for start/end, respectively.
- Change diag point colors to yellow/red for distinction.
- Use smaller dimension of the camera frame to determine scaling, instead of naively using Y.

Closes #92.
