### PR TITLE
Adjust component versions for 0.6 Windows EXE

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ The latest versions of these regulations are available at the
 
 ## Building a release
 
+- **IMPORTANT:** Create a clean virtual environment.  Do not update `setuptools` in it. Verify that
+  `setuptools` version is `56.0.0` via `pip show setuptools`.
+
 - Tag the latest stable commit in `master` with the desired version using a scheme that complies with PEP 440.
 
 - Switch to the project's root directory.

--- a/setup.cfg
+++ b/setup.cfg
@@ -66,7 +66,7 @@ install_requires =
     platformdirs >= 2.3
     opencv-python == 4.5.3.56;platform_system=='Windows'
     # For building frozen executables
-    pyinstaller == 4.5.1
+    pyinstaller == 5.7.0
     PySide6 >= 6.1
     pylint
     pytest

--- a/setup.cfg
+++ b/setup.cfg
@@ -64,7 +64,7 @@ install_requires =
     imutils @ git+https://github.com/basil96/imutils.git@dev
     numpy >= 1.21
     platformdirs >= 2.3
-    opencv-python >= 4.5.3;platform_system=='Windows'
+    opencv-python == 4.5.3.56;platform_system=='Windows'
     # For building frozen executables
     pyinstaller == 4.5.1
     PySide6 >= 6.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -62,7 +62,7 @@ install_requires =
     # To list a private GitHub repo as a dependency, see the following:
     # https://stackoverflow.com/questions/18026980/python-setuptools-how-can-i-list-a-private-repository-under-install-requires
     imutils @ git+https://github.com/basil96/imutils.git@dev
-    numpy >= 1.21
+    numpy == 1.21.0
     platformdirs >= 2.3
     opencv-python == 4.5.3.56;platform_system=='Windows'
     # For building frozen executables
@@ -72,7 +72,7 @@ install_requires =
     pytest
     # pytest-qt
     qtawesome >= 1.1.0
-    scipy >= 1.7
+    scipy == 1.7.0
 
 [options.packages.find]
 include = videof2b

--- a/setup.cfg
+++ b/setup.cfg
@@ -66,7 +66,7 @@ install_requires =
     platformdirs >= 2.3
     opencv-python >= 4.5.3;platform_system=='Windows'
     # For building frozen executables
-    pyinstaller >= 4.5.1
+    pyinstaller == 4.5.1
     PySide6 >= 6.1
     pylint
     pytest


### PR DESCRIPTION
Packaged Win EXE triggers too many popular anti-virus vendors (as reported by VirusTotal).  I've tinkered with several core components of the projects and found a combination of versions that strikes a decent balance between a usable application vs. as few AV triggers as possible.

Pending final testing on a few typical Windows systems (Win 7/10/11 if possible), this should become the `0.6` release.